### PR TITLE
Ready for 1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+### 1.5.0
+
+* Se hizo un FIX sobre un ID que provocaba que en algunos casos no se enviarán algunas  notificaciones
+
+Compatible con:
+* `leyesabiertas-core:1.5.0`
+* `leyesabiertas-web:1.5.0`
+
 ### 1.3.0
 
 * Se hizo un FIX donde el link a la propuesta se parseaba como `Object` y habia que sacar el `id`

--- a/api/controllers/comment-new.js
+++ b/api/controllers/comment-new.js
@@ -58,7 +58,7 @@ exports.post = async (req, res) => {
         email: commentInfo[0].user[0].email
       },
       document: {
-        id: commentInfo[0].document[0]._id,
+        id: commentInfo[0].document.id,
         title: commentInfo[0].version[0].content.title
       },
       comment: {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "democracyos-api-notifier",
-  "version": "1.3.0",
+  "version": "1.5.0",
   "description": "API Notifications",
   "main": "server.js",
   "scripts": {


### PR DESCRIPTION
* Se hizo un FIX sobre un ID que provocaba que en algunos casos no se enviarán algunas  notificaciones

Compatible con:
* `leyesabiertas-core:1.5.0`
* `leyesabiertas-web:1.5.0`